### PR TITLE
oem: Add missing <cstdint> include

### DIFF
--- a/src/oem.cpp
+++ b/src/oem.cpp
@@ -4,6 +4,7 @@
 
 #include "oem.h"
 #include <array>
+#include <cstdint>
 
 namespace libsiedler2 {
 


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes and so <cstdint> etc is no longer transitively included.

See https://www.gnu.org/software/gcc/gcc-13/porting_to.html.

Closes: https://github.com/Return-To-The-Roots/libsiedler2/issues/20
Bug: https://bugs.gentoo.org/891713