### PR TITLE
Automatic fixes of clang-tidy warnings: misc-unused-using-decls,moder…

### DIFF
--- a/include/libsiedler2/ColorBGRA.h
+++ b/include/libsiedler2/ColorBGRA.h
@@ -53,8 +53,8 @@ inline bool operator!=(const ColorBGRA& lhs, const ColorBGRA& rhs)
     return !(lhs == rhs);
 }
 
-inline constexpr ColorBGRA::ColorBGRA(uint8_t b, uint8_t g, uint8_t r, uint8_t a) : value{b, g, r, a} {}
-inline constexpr ColorBGRA::ColorBGRA(ColorRGB clrRGB, uint8_t a) : ColorBGRA(clrRGB.b, clrRGB.g, clrRGB.r, a) {}
+constexpr ColorBGRA::ColorBGRA(uint8_t b, uint8_t g, uint8_t r, uint8_t a) : value{b, g, r, a} {}
+constexpr ColorBGRA::ColorBGRA(ColorRGB clrRGB, uint8_t a) : ColorBGRA(clrRGB.b, clrRGB.g, clrRGB.r, a) {}
 inline ColorBGRA::ColorBGRA(const void* bgraBuffer)
 {
     std::memcpy(value.data(), bgraBuffer, 4);

--- a/include/libsiedler2/PixelBuffer.h
+++ b/include/libsiedler2/PixelBuffer.h
@@ -28,10 +28,10 @@ public:
     uint16_t getHeight() const { return height_; }
     uint32_t getSizeInBytes() const { return static_cast<uint32_t>(getNumPixels() * sizeof(T_Pixel)); }
     uint32_t getNumPixels() const { return static_cast<uint32_t>(pixels_.size()); }
-    uint8_t* getPixelPtr() { return pixels_.empty() ? nullptr : reinterpret_cast<uint8_t*>(&pixels_[0]); }
+    uint8_t* getPixelPtr() { return pixels_.empty() ? nullptr : reinterpret_cast<uint8_t*>(pixels_.data()); }
     const uint8_t* getPixelPtr() const
     {
-        return pixels_.empty() ? nullptr : reinterpret_cast<const uint8_t*>(&pixels_[0]);
+        return pixels_.empty() ? nullptr : reinterpret_cast<const uint8_t*>(pixels_.data());
     }
     std::vector<T_Pixel>& getPixels() { return pixels_; }
     const std::vector<T_Pixel>& getPixels() const { return pixels_; }

--- a/src/ArchivItem_Bitmap_Raw.cpp
+++ b/src/ArchivItem_Bitmap_Raw.cpp
@@ -69,7 +69,7 @@ int libsiedler2::baseArchivItem_Bitmap_Raw::load(std::istream& file, const Archi
     // Speicher anlegen
     if(length > 0)
     {
-        int ec = create(&data[0], width, height, TextureFormat::Paletted, palette);
+        int ec = create(data.data(), width, height, TextureFormat::Paletted, palette);
         if(ec)
             return ec;
         ec = convertFormat(outFormat);

--- a/src/ArchivItem_Sound_XMidi.cpp
+++ b/src/ArchivItem_Sound_XMidi.cpp
@@ -117,7 +117,7 @@ int ArchivItem_Sound_XMidi::load(std::istream& file, uint32_t length)
                 return ErrorCode::WRONG_FORMAT;
             tracklist[track_nr].getTimbres().resize(numTimbres);
             if(numTimbres > 0)
-                fs.readRaw(&tracklist[track_nr].getTimbres()[0], numTimbres);
+                fs.readRaw(tracklist[track_nr].getTimbres().data(), numTimbres);
             fs >> chunkId;
         }
         if(!isChunk(chunkId, "EVNT"))
@@ -177,7 +177,7 @@ int ArchivItem_Sound_XMidi::write(std::ostream& file) const
             fs.write("TIMB", 4);
             fs << uint32_t(track.getTimbres().size() * 2 + 2);
             fsLE << uint16_t(track.getTimbres().size());
-            fs.writeRaw(&track.getTimbres()[0], track.getTimbres().size());
+            fs.writeRaw(track.getTimbres().data(), track.getTimbres().size());
         }
         fs.write("EVNT", 4);
         fs << uint32_t(track.getData().size());

--- a/src/LoadBMP.cpp
+++ b/src/LoadBMP.cpp
@@ -29,7 +29,7 @@ static int read_palette(ArchivItem_BitmapBase& bitmap, T_FStream& bmpFs, const B
     if(numClrsUsed > 0)
     {
         std::array<ColorBGRA, 256> colors;
-        if(!bmpFs.read(reinterpret_cast<char*>(&colors[0]), numClrsUsed * 4))
+        if(!bmpFs.read(reinterpret_cast<char*>(colors.data()), numClrsUsed * 4))
             return ErrorCode::UNEXPECTED_EOF;
 
         auto pal = getAllocator().create<ArchivItem_Palette>(BobType::Palette);
@@ -203,7 +203,7 @@ int loader::LoadBMP(const boost::filesystem::path& filepath, Archiv& image,
         return ErrorCode::UNEXPECTED_EOF;
     }
 
-    if(int ec = bitmap->create(bmih.width, bmih.height, &buffer[0], bmih.width, bmih.height, format))
+    if(int ec = bitmap->create(bmih.width, bmih.height, buffer.data(), bmih.width, bmih.height, format))
         return ec;
     if(ArchivItem_BitmapBase::getWantedFormat(bitmap->getFormat()) != bitmap->getFormat())
     {

--- a/src/MIDI_Track.cpp
+++ b/src/MIDI_Track.cpp
@@ -23,7 +23,7 @@ int MIDI_Track::read(std::istream& file, size_t length)
         return ErrorCode::NONE;
 
     mid_data.resize(length);
-    if(!file.read(reinterpret_cast<char*>(&mid_data[0]), length))
+    if(!file.read(reinterpret_cast<char*>(mid_data.data()), length))
         return ErrorCode::UNEXPECTED_EOF;
     return ErrorCode::NONE;
 }
@@ -37,7 +37,7 @@ const uint8_t* MIDI_Track::getMid() const
 {
     if(mid_data.empty())
         return nullptr;
-    return &mid_data[0];
+    return mid_data.data();
 }
 
 uint32_t MIDI_Track::getMidLength() const


### PR DESCRIPTION
…nize-use-auto,performance-inefficient-vector-operation,performance-move-const-arg,readability-container-size-empty,readability-redundant-member-init,performance-noexcept-swap,readability-redundant-inline-specifier,readability-container-data-pointer